### PR TITLE
muzima-309:Create linkage with registration form

### DIFF
--- a/api/src/main/java/org/openmrs/module/muzima/api/service/DataService.java
+++ b/api/src/main/java/org/openmrs/module/muzima/api/service/DataService.java
@@ -97,6 +97,16 @@ public interface DataService extends OpenmrsService {
     ErrorData getErrorDataByUuid(final String uuid);
 
     /**
+     * Return the registration error data with the given patientUuid.
+     *
+     * @param patientUuid the error data patientUuid.
+     * @return the error data with the matching uuid.
+     * @should return error data with matching uuid.
+     * @should return null when no error data with matching uuid.
+     */
+    ErrorData getRegistrationErrorDataByPatientUuid(final String patientUuid);
+
+    /**
      * Return all saved error data.
      *
      * @return all saved error data.

--- a/api/src/main/java/org/openmrs/module/muzima/api/service/impl/DataServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/muzima/api/service/impl/DataServiceImpl.java
@@ -13,6 +13,7 @@
  */
 package org.openmrs.module.muzima.api.service.impl;
 
+import org.apache.commons.lang.StringUtils;
 import org.openmrs.Person;
 import org.openmrs.Role;
 import org.openmrs.api.context.Context;
@@ -201,6 +202,26 @@ public class DataServiceImpl extends BaseOpenmrsService implements DataService {
     @Override
     public ErrorData getErrorDataByUuid(final String uuid) {
         return getErrorDataDao().getDataByUuid(uuid);
+    }
+
+    /**
+     * Return the registration error data with the given patientUuid.
+     *
+     * @param patientUuid the error data uuid.
+     * @return the registration error data with the matching patientUuid.
+     * @should return registration error data with matching patientUuid.
+     * @should return null when no registration error data with matching patientUuid.
+     */
+    @Override
+    public ErrorData getRegistrationErrorDataByPatientUuid(String patientUuid) {
+
+        List<ErrorData> errors = getErrorDataDao().getPagedData(patientUuid, null, null);
+        for(ErrorData errorData : errors){
+            if(StringUtils.equals("json-registration", errorData.getDiscriminator())){
+                return errorData;
+            }
+        }
+        return null;
     }
 
     /**

--- a/omod/src/main/java/org/openmrs/module/muzima/web/utils/WebConverter.java
+++ b/omod/src/main/java/org/openmrs/module/muzima/web/utils/WebConverter.java
@@ -15,10 +15,12 @@ package org.openmrs.module.muzima.web.utils;
 
 import com.jayway.jsonpath.JsonPath;
 import net.minidev.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.openmrs.Location;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.muzima.api.service.DataService;
 import org.openmrs.module.muzima.model.DataSource;
 import org.openmrs.module.muzima.model.ErrorData;
 import org.openmrs.module.muzima.model.ErrorMessage;
@@ -95,11 +97,18 @@ public class WebConverter {
             }
             map.put("submitted", Context.getDateFormat().format(errorData.getDateCreated()));
             map.put("processed", Context.getDateFormat().format(errorData.getDateProcessed()));
-
+            map.put("regErrorUuid", emptyString);
             if(errorData.getPatientUuid() == null){
                 map.put("patientUuid", emptyString);
             } else {
                 map.put("patientUuid", errorData.getPatientUuid());
+                //get the registration errordata uuid if any for this patient
+                if(!StringUtils.equals("json-registration",errorData.getDiscriminator())){
+                    ErrorData regErrorData = getRegErrorData(errorData.getPatientUuid());
+                    if(regErrorData != null){
+                        map.put("regErrorUuid", regErrorData.getUuid());
+                    }
+                }
             }
 
             Map<String, Object> errorMap = new HashMap<String, Object>();
@@ -110,6 +119,14 @@ public class WebConverter {
             map.put("Errors", JSONObject.toJSONString(errorMap));
         }
         return map;
+    }
+
+    private static ErrorData getRegErrorData(String patientUuid) {
+        if (Context.isAuthenticated()) {
+            DataService dataService = Context.getService(DataService.class);
+            return dataService.getRegistrationErrorDataByPatientUuid(patientUuid);
+        }
+        return null;
     }
 
     public static Map<String, Object> convertEditRegistrationData(final ErrorData errorData) {

--- a/omod/src/main/webapp/resources/partials/error.html
+++ b/omod/src/main/webapp/resources/partials/error.html
@@ -45,6 +45,12 @@
                 <td>&nbsp;</td>
                 <td>&nbsp;</td>
             </tr>
+            <tr ng-hide = "error.discriminator == 'json-registration'">
+                <td>Registration Error</td>
+                <td><a href="#/error/{{error.regErrorUuid}}">Registration Error</a></td>
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+            </tr>
             <tr>
                 <td>Submitted On</td>
                 <td>{{error.submitted}}</td>


### PR DESCRIPTION
1)When there is a registration error for a particular patientUuid, then the link to the registration error should be provided in NON-registration error so that the user can resolve the registration error first.

Code changes:
*Introduced a new method to get ErrorData by patientUuid.
*Use the above api to retrieve ErrorData corresponding to the patientUuid & show a link to view that data in non-registration error data.
Changes in : error.html